### PR TITLE
Sinatra problem detail extention

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ProblemDetails is an implementation of [RFC7807 Problem Details for HTTP APIs](h
 The RFC defines a "problem detail" as a way to inform errors to clients as machine readable form in a HTTP response
 to avoid the need to define new error response formats for HTTP APIs.
 
-This library also works with Rails, by the `problem` renderer that helps to respond with the problem detail form.
+This library also works with Rails and Sinatra, by the `problem` renderer that helps to respond with the problem detail form.
 
 Currently only JSON serialization is supported.
 
@@ -26,6 +26,12 @@ Or if you use with Rails, add below line instead.
 
 ```ruby
 gem 'problem_details-rails'
+```
+
+With Sinatra, add below line instead.
+
+```ruby
+gem 'sinatra-problem_details'
 ```
 
 And then execute:
@@ -106,7 +112,7 @@ will produce(note that `balance` and `accounts` are extention members):
 
 ### With Rails
 
-Once `render_problems-rails` gem is installed into a Rails system, a problem can be rendered with the problem detail form with `Content-Type: application/problem+json`.
+Once `problem_details-rails` gem is installed into a Rails system, a problem can be rendered with the problem detail form with `Content-Type: application/problem+json`.
 
 For example, respond with validation error messages:
 
@@ -142,6 +148,54 @@ Content-Type: application/problem+json; charset=utf-8
 }
 ```
 
+### With Sinatra
+
+Install `sinatra-problems_details` into a sinatra app, a problem is be rendered as well with `Content-Type: application/problem+json`.
+
+#### Classic Application
+
+```ruby
+require 'sinatra'
+require 'sinatra-problem_details'
+
+get '/' do
+  status 400
+  problem foo: 'bar'
+end
+```
+
+#### Modular Application
+
+```ruby
+require 'sinatra/base'
+require 'sinatra-problem_details'
+
+class MyApp < Sinatra::Base
+  register Sinatra::ProblemDetails
+
+  get '/' do
+    status 400
+    problem foo: 'bar'
+  end
+end
+```
+
+#### Response
+
+The sinatra apps defined in the previous sections will render:
+
+```
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+
+{
+  "type": "about:blank",
+  "title": "Bad Request",
+  "status": 400,
+  "foo": "bar"
+  }
+}
+```
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,14 +20,26 @@ namespace 'problem_details-rails' do
   ProblemDetailsRailsGemHelper.install_tasks dir: File.join(__dir__, 'problem_details-rails'), name: 'problem_details-rails'
 end
 
+namespace 'sinatra-problem_details' do
+  class SinatraProblemDetailsGemHelper < Bundler::GemHelper
+    def guard_already_tagged; end # noop
+
+    def tag_version; end # noop
+  end
+
+  SinatraProblemDetailsGemHelper.install_tasks dir: File.join(__dir__, 'sinatra-problem_details'), name: 'sinatra-problem_details'
+end
+
+
+
 desc 'build gem'
-task build: ['problem_details:build', 'problem_details-rails:build']
+task build: ['problem_details:build', 'problem_details-rails:build', 'sinatra-problem_details:build']
 
 desc 'build and install'
-task install: ['problem_details:install', 'problem_details-rails:install']
+task install: ['problem_details:install', 'problem_details-rails:install', 'sinatra-problem_details:build']
 
 desc 'release'
-task release: ['problem_details:release', 'problem_details-rails:release']
+task release: ['problem_details:release', 'problem_details-rails:release', 'sinatra-problem_details:build']
 
 RSpec::Core::RakeTask.new(:spec)
 task default: 'spec:all'
@@ -36,6 +48,7 @@ namespace :spec do
   dirs = %w(
     .
     problem_details-rails
+    sinatra-problem_details
   )
 
   desc "Run all specs"

--- a/Rakefile
+++ b/Rakefile
@@ -55,8 +55,10 @@ namespace :spec do
   task :all do
     dirs.each do |d|
       Dir.chdir(d) do
-        sh 'bundle --quiet'
-        sh 'bundle exec rake spec'
+        Bundler.with_clean_env do
+          sh 'bundle --quiet'
+          sh 'bundle exec rake spec'
+        end
       end
     end
   end

--- a/sinatra-problem_details/.gitignore
+++ b/sinatra-problem_details/.gitignore
@@ -1,0 +1,12 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status
+Gemfile.lock

--- a/sinatra-problem_details/.rspec
+++ b/sinatra-problem_details/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/sinatra-problem_details/Gemfile
+++ b/sinatra-problem_details/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+gemspec

--- a/sinatra-problem_details/LICENSE.txt
+++ b/sinatra-problem_details/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Nobuhiro Nikushi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/sinatra-problem_details/README.md
+++ b/sinatra-problem_details/README.md
@@ -1,0 +1,6 @@
+# Sinatra::ProblemDetails [![Build Status](https://travis-ci.org/nikushi/problem_details.svg?branch=master)](https://travis-ci.org/nikushi/problem_details) [![Gem Version](https://badge.fury.io/rb/problem_details.svg)](https://badge.fury.io/rb/problem_details)
+
+Sinatra::ProblemDetails adds a helper method, called `problem`, for "problem detail" json response,
+described in [RFC7807 Problem Details for HTTP APIs](https://tools.ietf.org/html/rfc7807).
+
+See the detail at [nikushi/problem_details](https://github.com/nikushi/problem_details).

--- a/sinatra-problem_details/Rakefile
+++ b/sinatra-problem_details/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/sinatra-problem_details/lib/sinatra-problem_details.rb
+++ b/sinatra-problem_details/lib/sinatra-problem_details.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'sinatra/problem_details'

--- a/sinatra-problem_details/lib/sinatra/problem_details.rb
+++ b/sinatra-problem_details/lib/sinatra/problem_details.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'sinatra/base'
+require 'sinatra/json'
+require 'problem_details'
+
+module Sinatra
+  module ProblemDetails
+    module Helpers
+      def problem(object, options = {})
+        options = { content_type: settings.problem_json_content_type }.merge(options)
+        document = ::ProblemDetails::Document.new(status: status, **object)
+        json(document.to_h, options)
+      end
+    end
+
+    def self.registered(base)
+      base.set :problem_json_content_type, 'application/problem+json'
+      base.helpers Helpers
+    end
+  end
+
+  register ProblemDetails
+end

--- a/sinatra-problem_details/sinatra-problem_details.gemspec
+++ b/sinatra-problem_details/sinatra-problem_details.gemspec
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+version = File.read(File.expand_path('../VERSION', __dir__)).strip
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name          = 'sinatra-problem_details'
+  spec.version       = version
+  spec.authors       = ['Nobuhiro Nikushi']
+  spec.email         = ['deneb.ge@gmail.com']
+
+  spec.summary       = 'Sinatra extention to add +problem+ method to respond with RFC 7807 Problem Details form'
+  spec.description   = spec.summary
+  spec.homepage      = 'https://github.com/nikushi/problem_details'
+  spec.license       = 'MIT'
+
+  spec.files         = Dir['lib/**/*.rb'] + %w[
+    LICENSE.txt
+    README.md
+    Rakefile
+    sinatra-problem_details.gemspec
+  ]
+  spec.require_paths = ['lib']
+
+  spec.add_runtime_dependency 'problem_details', version
+  spec.add_runtime_dependency 'sinatra-contrib'
+  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+end

--- a/sinatra-problem_details/sinatra-problem_details.gemspec
+++ b/sinatra-problem_details/sinatra-problem_details.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rack-test'
 end

--- a/sinatra-problem_details/spec/problem_spec.rb
+++ b/sinatra-problem_details/spec/problem_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+RSpec.describe Sinatra::ProblemDetails do
+  def mock_app(&block)
+    super do
+      register Sinatra::ProblemDetails
+      class_eval(&block)
+    end
+  end
+
+  def results_in(obj)
+    expect(JSON.parse(get('/').body)).to eq(obj)
+  end
+
+  it "encodes objects with default status" do
+    mock_app { get('/') { problem :foo => [1, 'bar', nil] } }
+    results_in 'status' => 200, 'title' => 'OK', 'type' => 'about:blank', 'foo' => [1, 'bar', nil]
+  end
+
+  it "encodes objects with given status" do
+    mock_app do
+      get('/') do
+        status 404
+        problem :foo => [1, 'bar', nil]
+      end
+    end
+    results_in 'status' => 404, 'title' => 'Not Found', 'type' => 'about:blank', 'foo' => [1, 'bar', nil]
+  end
+
+  it "encodes objects with given symbol status" do
+    mock_app do
+      get('/') do
+        status :forbidden
+        problem :foo => [1, 'bar', nil]
+      end
+    end
+    results_in 'status' => 403, 'title' => 'Forbidden', 'type' => 'about:blank', 'foo' => [1, 'bar', nil]
+  end
+
+  it "encodes objects with status and other properties including reserved ones in RFC" do
+    mock_app do
+      get('/') do
+        status 403
+        problem(
+          type: 'https://example.com/probs/out-of-credit',
+          title: 'You do not have enough credit.',
+          detail: 'Your current balance is 30, but that costs 50.',
+          instance: '/account/12345/msgs/abc',
+          balance: 30,
+          accounts: ['/account/12345', '/account/67890'],
+        )
+      end
+    end
+    results_in(
+      'status' => 403,
+      'type' => 'https://example.com/probs/out-of-credit',
+      'title' => 'You do not have enough credit.',
+      'detail' => 'Your current balance is 30, but that costs 50.',
+      'instance' => '/account/12345/msgs/abc',
+      'balance' => 30,
+      'accounts' => ['/account/12345', '/account/67890'],
+    )
+  end
+
+  it "sets the content type to 'application/problem+json'" do
+    mock_app { get('/') { problem({}) } }
+    expect(get('/')["Content-Type"]).to include("application/problem+json")
+  end
+
+  it "allows overriding content type with :content_type" do
+    mock_app { get('/') { json({}, :content_type => "application/json") } }
+    expect(get('/')["Content-Type"]).to eq("application/json")
+  end
+end

--- a/sinatra-problem_details/spec/spec_helper.rb
+++ b/sinatra-problem_details/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+ENV['RACK_ENV'] = 'test'
 require 'bundler/setup'
+
+require 'sinatra/contrib'
 require 'sinatra-problem_details'
 
 RSpec.configure do |config|
@@ -13,4 +16,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include Sinatra::TestHelpers
 end

--- a/sinatra-problem_details/spec/spec_helper.rb
+++ b/sinatra-problem_details/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'sinatra-problem_details'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
Let's support sinatra.

sinatra-problem_details gem lets sinatra apps `problem` helper as a request level method. 