### PR TITLE
Use GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ 2.4, 2.5, 2.6, 2.7, 3.0, jruby, truffleruby ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+    - name: Build and test with RSpec
+      run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
-  - ruby-head
-before_install: gem install bundler -v 1.16.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# ProblemDetails [![Build Status](https://travis-ci.org/nikushi/problem_details.svg?branch=master)](https://travis-ci.org/nikushi/problem_details) [![Gem Version](https://badge.fury.io/rb/problem_details.svg)](https://badge.fury.io/rb/problem_details)
+# ProblemDetails
+
+[![CI](https://github.com/nikushi/problem_details/actions/workflows/ci.yml/badge.svg)](https://github.com/nikushi/problem_details/actions/workflows/ci.yml)
+[![Gem Version](https://badge.fury.io/rb/problem_details.svg)](https://badge.fury.io/rb/problem_details)
 
 ProblemDetails is an implementation of [RFC7807 Problem Details for HTTP APIs](https://tools.ietf.org/html/rfc7807).
 


### PR DESCRIPTION
Travis has been having issues - being slow/non-functional, especially. This moves the CI over to GitHub Actions.

The Action ran on my fork and all Jobs finished successfully ✅.

<img width="1259" alt="Use_GitHub_Actions_·_stevenharman_problem_details_17e1c06" src="https://user-images.githubusercontent.com/48658/131731108-eec673bb-d385-487c-9d60-e4a2065a5915.png">
