### PR TITLE
To hash protocol conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased / ???
+
+* Support the `#to_hash` implicit conversion protocol (#8) by @stevenharman
+
 ## 0.2.2 / 2019-10-30
 
 * Remove default about:blank type (#5) by @akrawchyk
@@ -9,7 +13,7 @@
 ## 0.2.0 / 2018-03-20
 
 ### Enhancements:
-* Introduce a new gem, `sinatra-problem_details`, the Sinatra problem detail extention.
+* Introduce a new gem, `sinatra-problem_details`, the Sinatra problem detail extension.
 
 ## 0.1.0 / 2018-03-26
 

--- a/lib/problem_details/document.rb
+++ b/lib/problem_details/document.rb
@@ -19,7 +19,7 @@ module ProblemDetails
       @extentions = params
     end
 
-    def to_h
+    def to_hash
       h = {}
       %i[type title status detail instance].each do |key|
         value = public_send(key)
@@ -27,9 +27,10 @@ module ProblemDetails
       end
       h.merge(@extentions)
     end
+    alias_method :to_h, :to_hash
 
     def to_json
-      to_h.to_json
+      to_hash.to_json
     end
   end
 end


### PR DESCRIPTION
A `Document` instance can reasonably be expected to also have a Hash representation, so it makes sense to provide a `#to_hash`. We also provide the explicit `#to_h` protocol. For more on this "protocol" talk, see this [oldie-but-goodie from our friend Avdi](https://avdi.codes/define-conversion-protocols-in-ruby/).

**NOTE**: This is build upon #7. When that's merged or closed, I'll rebase those changes out of this PR.

Thank you!