### PR TITLE
Update ci.yml for ruby 3.1 + fix unquoted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.4, 2.5, 2.6, 2.7, 3.0, jruby, truffleruby ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', 'jruby', 'truffleruby' ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- Quote ruby versions to avoid https://github.com/actions/runner/issues/849

![image](https://user-images.githubusercontent.com/713525/149531350-46634e92-03ed-4b78-b3f2-e3e758c4e5ab.png)

- Add 3.1 to the matrix